### PR TITLE
htofix: filter out projects with invalid dates

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -29,6 +29,7 @@ class HomeController extends Controller
 
             'projects' => ProjectCardResource::collection(
                 Project::whereIsOpen()
+                    ->validDates('start','end')
                     ->latest()
                     ->limit(12)
                     ->get()
@@ -37,6 +38,7 @@ class HomeController extends Controller
             'bcr_projects' => BCRProjectCardResource::collection(
                 BCRProject::query()
                     ->where('status', ProjectStatus::approved)
+                    ->validDates()
                     ->latest()
                     ->with('county')
                     ->limit(12)

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -62,7 +62,8 @@ class ProjectController extends Controller
                 AllowedSort::custom('donations_count', new ProjectDonationsCountSort),
             ])
             ->defaultSort('-id')
-            ->whereIsPublished();
+            ->whereIsPublished()
+            ->validDates('start', 'end');
 
         return Inertia::render('Public/Projects/Index', [
             'view' => $view,

--- a/app/Models/BCRProject.php
+++ b/app/Models/BCRProject.php
@@ -8,6 +8,7 @@ use App\Concerns\HasLocation;
 use App\Concerns\HasSlug;
 use App\Enums\ProjectStatus;
 use App\Traits\HasProjectStatus;
+use App\Traits\HasValidDates;
 use Embed\Embed;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -23,6 +24,7 @@ class BCRProject extends Model implements HasMedia
 {
     use HasFactory;
     use HasLocation;
+    use HasValidDates;
     use InteractsWithMedia;
     use HasProjectStatus;
     use HasSlug;
@@ -90,12 +92,12 @@ class BCRProject extends Model implements HasMedia
     {
         return collect($this->videos)
             ->pluck('link')
-            ->filter(fn ($video) => ! blank($video))
+            ->filter(fn($video) => ! blank($video))
             ->map(
-                fn (string $videoUrl) => Cache::remember(
+                fn(string $videoUrl) => Cache::remember(
                     'video-' . hash('sha256', $videoUrl),
                     MONTH_IN_SECONDS,
-                    fn () => rescue(fn () => (new Embed)->get($videoUrl)->code, '', false)
+                    fn() => rescue(fn() => (new Embed)->get($videoUrl)->code, '', false)
                 )
             )
             ->filter()

--- a/app/Traits/HasValidDates.php
+++ b/app/Traits/HasValidDates.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Database\Eloquent\Builder;
+
+trait HasValidDates
+{
+    public function scopeValidDates(Builder $query, string $startColumn = 'start_date', string $endColumn = 'end_date'): Builder
+    {
+        return $query
+            ->whereNotNull($startColumn)
+            ->whereNotNull($endColumn)
+            ->whereColumn($startColumn, '<=', $endColumn);
+    }
+}


### PR DESCRIPTION
- Make isActive and isPeriodActive null-safe (avoids runtime error)
- Filter out projects with invalid or missing dates in queries (avoids the user seeing projects with invalid dates)